### PR TITLE
Add more documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ ADD requirements.txt /src/requirements.txt
 
 WORKDIR "/src"
 
+
 RUN pip install -r requirements.txt
 ADD . /src
 
 EXPOSE 9999
+
+ENV IN_CONTAINER=1
 
 CMD [ "python3", "-m", "JobRunner.Callback"]

--- a/JobRunner/Callback.py
+++ b/JobRunner/Callback.py
@@ -11,7 +11,7 @@ import json
 class Callback():
     def __init__(self):
         workdir = os.environ.get("JOB_DIR", '/tmp/')
-        self.conf = Config(workdir=workdir, use_ee2=False)
+        self.conf = Config(job_id="callback", workdir=workdir, use_ee2=False)
         self.ip = os.environ.get('CALLBACK_IP', get_ip())
         self.port = os.environ.get('CALLBACK_PORT')
         self.cbs = None

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ the JobRunner is currently testing against Python 3.9.
 ```
 pip install .
 # Set the DOCKER_HOST if this doesn't work out of the box
+# Note the location of the socket file may vary based on
+# your container runtime installation.
 export DOCKER_HOST=unix://$HOME/.docker/run/docker.sock
 
 # Set job dir where work output will go
+# Note you may need to set the permissions to world writeable
+# depending on your container runtime installation.
 export JOB_DIR=/full/path/to/work/area
 
 # Set tokens and URL

--- a/README.md
+++ b/README.md
@@ -2,6 +2,87 @@
 
 The job runner is started by the batch/resource manager system and is the component that actually executes the SDK module.  It also provides the callback handler and pushes logs to the execution engine logging system.
 
+## Callback Server Mode
+
+It is possible to run the callback server in a standalone mode.  This can be used to speed up
+testing of SDK apps (avoiding a full make test cycle) or to allow some automated operations.
+The callback server can be launched in a few ways.
+
+### Native Launch
+
+To launch the callback server natively you can do the following.
+
+```
+pip install .
+# Set the DOCKER_HOST if this doesn't work out of the box
+export DOCKER_HOST=unix://$HOME/.docker/run/docker.sock
+
+# Set job dir where work output will go
+export JOB_DIR=/full/path/to/work/area
+
+# Set tokens and URL
+export KB_AUTH_TOKEN="xxxxxxxxx"
+export KB_ADMIN_AUTH_TOKEN="xxxxxxxxxxxx"
+export KB_BASE_URL=https://ci.kbase.us/services
+
+# Optional
+export KB_REF_DATA=/path/to/local/refdata
+
+# Launch the callback server
+python -m JobRunner.callback
+```
+
+### Container Launch
+
+The callback server can also be launched via a container.  This may be useful
+where the local python and what works with the JobRunner are incompatible.
+Note that the JOB_DIR needs to be accessible by docker.  Also you must pass through
+the docker socket to the container.  The path to the socket can vary depending on
+the container runtime and how the container runtime is configured.
+
+```
+export JOB_DIR=/full/path/to/work/area
+export KB_AUTH_TOKEN="xxxxxxxxx"
+export KB_ADMIN_AUTH_TOKEN="xxxxxxxxxxxx"
+
+docker run --name cb -d \
+   -e KB_AUTH_TOKEN \
+   -e KB_ADMIN_AUTH_TOKEN \
+   -e KB_BASE_URL=https://ci.kbase.us/services \
+   -e IN_CONTAINER=1 \
+   -e CALLBACK_PORT=9999 \
+   -e JOB_DIR \
+   -v $JOB_DIR:$JOB_DIR \
+   -v /var/run/docker.sock:/run/docker.sock \
+   -p 9999:9999 \
+   ghcr.io/kbase/jobrunner:latest-rc
+
+export SDK_CALLBACK_URL=http://localhost:9999
+```
+
+## Development and Testing the Job Runner
+
+Here is a quick start guide for running test for the Job Runner code.
+See the SDK guide for information about running test of SDK apps.
+
+```
+pip install -r requirements.txt -r requirements-dev.txt
+
+# Set the DOCKER_HOST if this doesn't work out of the box
+export DOCKER_HOST=unix://$HOME/.docker/run/docker.sock
+
+# Set tokens and URL
+export KB_AUTH_TOKEN="xxxxxxxxx"
+export KB_ADMIN_AUTH_TOKEN="xxxxxxxxxxxx"
+export KB_BASE_URL=https://ci.kbase.us/services
+
+# Set ref data to an area acceessible by Docker
+export KB_REF_DATA=/path/to/local/refdata
+
+make mock
+make testimage
+make test
+```
 
 ## Debug Mode
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ docker run --name cb -d \
    -e KB_AUTH_TOKEN \
    -e KB_ADMIN_AUTH_TOKEN \
    -e KB_BASE_URL=https://ci.kbase.us/services \
-   -e IN_CONTAINER=1 \
    -e CALLBACK_PORT=9999 \
    -e JOB_DIR \
    -v $JOB_DIR:$JOB_DIR \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The callback server can be launched in a few ways.
 
 ### Native Launch
 
-To launch the callback server natively you can do the following.
+To launch the callback server natively you can do the following. Note that
+the JobRunner is currently testing against Python 3.9.
 
 ```
 pip install .

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ make testimage
 make test
 ```
 
+## Using the CallBack Server 
+* Install a kb-sdk module such as DataFileUtil using `kb-sdk install` or copying from an existing apps `lib/installed_clients` directory
+* Point that client to the callback server's IP and PORT
+* The follow example points the DataFileUtil client to the callback server to launch a DataFileUtil container and download a specific object 
+
+```
+from DataFileUtilClient import DataFileUtil
+callback_url = 'http://127.0.0.1:9999'
+token='<redacted>'
+dfu = DataFileUtil(callback_url, service_ver='dev', token=token)
+
+ref = '68940/2/1'
+data = dfu.get_objects({
+            'object_refs': [ref]
+        })['data'][0]
+print(data)
+```
+
 ## Debug Mode
 
 A debug mode can be enabled by setting the environment variable "JOBRUNNER_DEBUG_MODE" to "TRUE".


### PR DESCRIPTION
Should we add documentation on EE2 deployment here as well or anything about how to get variables from EE2 into this? or maybe in a separate issue?