### PR TITLE
Fix GHAs

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -6,6 +6,6 @@ jobs:
   build-push:
     uses: kbase/.github/.github/workflows/reusable_build-push.yml@main
     with:
-      name: '${{ github.event.repository.name }}-develop'
+      name: jobrunner-develop'
       tags: br-${{ github.ref_name }}
     secrets: inherit

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -20,6 +20,6 @@ jobs:
     needs: validate-release-tag
     uses: kbase/.github/.github/workflows/reusable_build-push.yml@main
     with:
-      name: '${{ github.event.repository.name }}'
+      name: jobrunner
       tags: '${{ github.event.release.tag_name }},latest'
     secrets: inherit


### PR DESCRIPTION
We have to hardcode the image name because the casing of the repo name causes problems.