### PR TITLE
DEVOPS-2030 Update JobRunner to work at NERSC by skipping cloudflare

### DIFF
--- a/JobRunner/JobRunner.py
+++ b/JobRunner/JobRunner.py
@@ -334,6 +334,16 @@ class JobRunner(object):
             self.logger.error("Failed to config . Exiting.")
             raise e
 
+        if "USE_SHIFTER" in os.environ:
+            # Replace URLs for NERSC environment if set to "https://services.kbase.us"
+            old_url = "https://services.kbase.us"
+            new_url = "https://kbase.us"
+            for key, value in config.items():
+                if isinstance(value, str) and old_url in value:
+                    config[key] = value.replace(old_url, new_url)
+
+
+
         config["job_id"] = self.job_id
         self.logger.log(
             f"Server version of Execution Engine: {config.get('ee.server.version')}"
@@ -373,7 +383,7 @@ class JobRunner(object):
 
         # Submit the main job
         self.logger.log(f"Job is about to run {job_params.get('app_id')}")
-
+        # Note the self.config is not used, its the ee2 config we just grabbed and modified
         # TODO Try except for when submit or watch failure happens and correct finishjob call
         self._submit(
             config=config, job_id=self.job_id, job_params=job_params, subjob=False

--- a/scripts/jobrunner.py
+++ b/scripts/jobrunner.py
@@ -152,7 +152,7 @@ def main():
     # WARNING: Condor job environment may not inherit from system ENV
     if "USE_SHIFTER" in os.environ:
 
-    config["runtime"] = "shifter"
+        config["runtime"] = "shifter"
 
         # Replace URLs for NERSC environment if set to "https://services.kbase.us"
         new_url = "https://kbase.us"

--- a/scripts/jobrunner.py
+++ b/scripts/jobrunner.py
@@ -151,19 +151,23 @@ def main():
 
     # WARNING: Condor job environment may not inherit from system ENV
     if "USE_SHIFTER" in os.environ:
-        config["runtime"] = "shifter"
-        
-        # This means we are at NERSC, and nersc cannot contact "services.kbase.us"
-        for key, value in os.environ.items():
-            if "services.kbase.us" in value:
-                os.environ[key] = value.replace("https://services.kbase.us", "https://kbase.us")
 
+    config["runtime"] = "shifter"
+
+        # Replace URLs for NERSC environment if set to "https://services.kbase.us"
+        new_url = "https://kbase.us"
+        old_url = "https://services.kbase.us"
+        
+        for key, value in os.environ.items():
+            if old_url in value:
+                os.environ[key] = value.replace(old_url, new_url)
+    
         for key, value in config.items():
-            if isinstance(value, str) and "https://services.kbase.us" in value:
-                config[key] = value.replace("https://services.kbase.us", "https://kbase.us")
-        
-        ee2_url = ee2_url.replace("https://services.kbase.us", "https://kbase.us")
-        
+            if isinstance(value, str) and old_url in value:
+                config[key] = value.replace(old_url, new_url)
+    
+        ee2_url = ee2_url.replace(old_url, new_url)
+            
 
 
     if "JR_MAX_TASKS" in os.environ:

--- a/scripts/jobrunner.py
+++ b/scripts/jobrunner.py
@@ -152,6 +152,19 @@ def main():
     # WARNING: Condor job environment may not inherit from system ENV
     if "USE_SHIFTER" in os.environ:
         config["runtime"] = "shifter"
+        
+        # This means we are at NERSC, and nersc cannot contact "services.kbase.us"
+        for key, value in os.environ.items():
+            if "services.kbase.us" in value:
+                os.environ[key] = value.replace("https://services.kbase.us", "https://kbase.us")
+
+        for key, value in config.items():
+            if isinstance(value, str) and "https://services.kbase.us" in value:
+                config[key] = value.replace("https://services.kbase.us", "https://kbase.us")
+        
+        ee2_url = ee2_url.replace("https://services.kbase.us", "https://kbase.us")
+        
+
 
     if "JR_MAX_TASKS" in os.environ:
         config["max_tasks"] = int(os.environ["JR_MAX_TASKS"])


### PR DESCRIPTION
* This is only on the ee2 branch, something similar should happen on the main branch
* Background, ee2 was changed to send requests and avoid cloudflare, so send them on the internal network
* The internal network is not accessible at nersc, so we have to send through cloudflare
* These changes/hack modify the job runner to replace that URL when it is running at NERSC to the public URL
* These changes are current deployed on production. You can run a hipmer job to prove it and see that they now run.
* Corresponding changes in ee2 are also deployed on production. https://github.com/kbase/execution_engine2/pull/489

You can run a job with the narrative or you can run this code

```
import os
from pprint import pprint
from lib.installed_clients.execution_engine2Client import execution_engine2
ee2 = execution_engine2(url='https://narrative.kbase.us/services/ee3', token=os.environ['KB_AUTH_TOKEN'])


# print(ee2.list_config())


# print(ee2.status())
# pprint(ee2.check_job({"job_id": "672514ac58decbd59f088bfb", 'as_admin': True}))# Define the job parameters based on RunJobParams structure and Mongo example
job_params = {
    "method": "hipmer.run_hipmer_hpc",  # Corresponding method for hipmer
    "app_id": "hipmer/run_hipmer_hpc_meta",  # App ID for hipmer
    "params": [{
        "output_contigset_name": "MHM2.contigs",
        "mer_sizes": "21,33,55,77,99",
        "scaff_mer_lens": "99,33",
        "reads": ["197108/6/1"],
        "assembly_size_filter": 2000,
        "read_Gbp_limit": 500,
        "usedebug": 0,
        "is_meta": 1,  # Indicates a meta-assembly
        "workspace_name": "bsadkhin:narrative_1730482994256"  # Workspace name
    }],
    "service_ver": "ed40108ef820bd8e9d4f3c0ad3840bc9cd3c75fe",  # Service version
    "source_ws_objects": ["197108/6/1"],  # Source workspace objects
    "meta": {},  # Meta information, can be filled as needed
    "wsid": 197108,  # Workspace ID
    # "job_requirements": {
    #     "client_group": "hpc",  # Client group for high-performance computing
    #     "request_cpus": 4,      # Requested CPU count
    #     "request_memory": 2000, # Requested memory in MB
    #     "request_disk": 100,    # Requested disk space in GB
    # },
    # "as_admin": 1  # Run job as admin if needed
}

# Submit the job
job_id = ee2.run_job(job_params)
print(f"Job submitted with ID: {job_id}")
```