### PR TITLE
Fix 500 + result bug & file write bug

### DIFF
--- a/JobRunner/JobRunner.py
+++ b/JobRunner/JobRunner.py
@@ -436,7 +436,7 @@ class JobRunner(object):
 
         self.prov = Provenance(job_params)
         self._init_workdir()
-        job_dir = self.workdir
+        job_dir = os.path.join(self.workdir, "workdir")  # TODO should handle this in mr
         # TODO: This is calling a private method.
         self.mr._init_workdir(config, job_dir, job_params)
         self.config.user = self._validate_token()

--- a/JobRunner/MethodRunner.py
+++ b/JobRunner/MethodRunner.py
@@ -115,8 +115,6 @@ class MethodRunner:
         if not os.path.exists(wdt):
             os.mkdir(wdt)
 
-        return True
-
     def _get_job_dir(self, job_id, subjob=False):
         if subjob:
             return os.path.join(self.subjobdir, job_id)
@@ -268,8 +266,6 @@ class MethodRunner:
             self.logger.error(
                 f"Job {job_id} ran, but {of} contained an error. Error in output job msg:{error_msg} code:{error_code} name:{error_name} error:{error_error}"
             )
-            if output.get("result") is None:
-                output["result"] = output.get("error")
 
         return output
 

--- a/JobRunner/callback_server.py
+++ b/JobRunner/callback_server.py
@@ -95,7 +95,7 @@ def _handle_checkjob(data):
         resp["finished"] = 1
         try:
             if "error" in resp:
-                return {"result": [resp], "error": resp["error"]}
+                return resp
         except Exception as e:
             logger.debug(e)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,12 @@
+# Job runner release notes
+
+## 0.1.0
+
+* Fixed a bug that could cause Java client failures when a result key was returned in an HTTP 500
+  response.
+* Fixed a bug that caused job files to be incorrectly written to the root job directory when
+  running in callback server only mode.
+
+## Earlier release notes
+
+... have been lost.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobrunner"
-version = "0.0.2"
+version = "0.1.0"
 description = "The EE2 JobRunner for kB_SDK apps."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -530,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "jobrunner"
-version = "0.0.2"
+version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "docker" },

--- a/version.py
+++ b/version.py
@@ -1,7 +1,7 @@
 version_info = (
     0,
+    1,
     0,
-    2,
 )
 __version__ = '.'.join(map(str, version_info[:3]))
 


### PR DESCRIPTION
* Fixed a bug that would return a result field in a HTTP 500 response in a couple of locations. This would cause java clients to incorrectly process the error.
* Fixed a bug that would cause job files to be written to `<job_root>` rather than `<job_root>/workdir`

In addition to the repo tests, updated kb_sdk_plus to use this version of the CBS in its `test` command code and ran the repo tests there, which passed