### PR TITLE
Switch CatalogCache to dependency injection

### DIFF
--- a/JobRunner/CatalogCache.py
+++ b/JobRunner/CatalogCache.py
@@ -2,14 +2,19 @@ from clients.CatalogClient import Catalog
 
 
 class CatalogCache(object):
-    def __init__(self, config):
-        self.admin_token = config.admin_token
-        self.catalog_url = config.catalog_url
-        self.catalog = Catalog(self.catalog_url, token=self.admin_token)
+
+    def __init__(self, catalog: Catalog, token: str = None):
+        """
+        Initialize the cache. If the catalog client has a token, it must be a catalog admin
+        token.
+        """
+        self.catalog = catalog
+        # TODO CODE add a method to SDK clients to get the token, then use that here
+        self.has_admin_token = bool(token)
         self.module_cache = dict()
 
     def get_volume_mounts(self, module, method, cgroup):
-        if self.admin_token is None:
+        if not self.has_admin_token:
             return []
         req = {"module_name": module, "function_name": method, "client_group": cgroup}
         resp = self.catalog.list_volume_mounts(req)
@@ -28,7 +33,7 @@ class CatalogCache(object):
             module_info = self.catalog.get_module_version(req)
             # Lookup secure params
             sp = []
-            if self.admin_token:
+            if self.has_admin_token:
                 req["load_all_versions"] = 0
                 sp = self.catalog.get_secure_config_params(req)
             module_info["secure_config_params"] = sp

--- a/test/test_catalogcache.py
+++ b/test/test_catalogcache.py
@@ -20,7 +20,7 @@ class CatalogCacheTest(unittest.TestCase):
         return CatalogCache(catalog, token="bogus"), catalog
 
     def test_cache(self):
-        cc, catalog  = self.get_mocks()
+        cc, catalog = self.get_mocks()
         catalog.get_module_version.return_value = CATALOG_GET_MODULE_VERSION
         out = cc.get_module_info("bogus", "method")
         self.assertIn("git_commit_hash", out)
@@ -33,7 +33,7 @@ class CatalogCacheTest(unittest.TestCase):
         self.assertIn("secure_config_params", out)
 
     def test_secure_params(self):
-        cc, catalog  = self.get_mocks()
+        cc, catalog = self.get_mocks()
         catalog.get_module_version.return_value = CATALOG_GET_MODULE_VERSION
         catalog.get_secure_config_params.return_value = (
             CATALOG_GET_SECURE_CONFIG_PARAMS
@@ -47,7 +47,7 @@ class CatalogCacheTest(unittest.TestCase):
         self.assertGreater(len(out["secure_config_params"]), 0)
 
     def test_volume(self):
-        cc, catalog  = self.get_mocks()
+        cc, catalog = self.get_mocks()
         vols = deepcopy(CATALOG_LIST_VOLUME_MOUNTS)
         catalog.list_volume_mounts.return_value = vols
         out = cc.get_volume_mounts("bogus", "method", "upload")

--- a/test/test_catalogcache.py
+++ b/test/test_catalogcache.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-import os
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import create_autospec
 
-from JobRunner.config import Config
 from JobRunner.CatalogCache import CatalogCache
 
 from copy import deepcopy
@@ -12,19 +10,18 @@ from mock_data import (
     CATALOG_LIST_VOLUME_MOUNTS,
     CATALOG_GET_SECURE_CONFIG_PARAMS,
 )
+from clients.CatalogClient import Catalog
 
 
 class CatalogCacheTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.token = os.environ.get("KB_AUTH_TOKEN", None)
-        cls.admin_token = os.environ.get("KB_ADMIN_AUTH_TOKEN", "bogus")
-        cls.cfg = Config()
 
-    @patch("JobRunner.CatalogCache.Catalog", autospec=True)
-    def test_cache(self, mock_cc):
-        cc = CatalogCache(self.cfg)
-        cc.catalog.get_module_version.return_value = CATALOG_GET_MODULE_VERSION
+    def get_mocks(self):
+        catalog = create_autospec(Catalog, spec_set=True, instance=True)
+        return CatalogCache(catalog, token="bogus"), catalog
+
+    def test_cache(self):
+        cc, catalog  = self.get_mocks()
+        catalog.get_module_version.return_value = CATALOG_GET_MODULE_VERSION
         out = cc.get_module_info("bogus", "method")
         self.assertIn("git_commit_hash", out)
         self.assertIn("cached", out)
@@ -35,11 +32,10 @@ class CatalogCacheTest(unittest.TestCase):
         self.assertTrue(out["cached"])
         self.assertIn("secure_config_params", out)
 
-    @patch("JobRunner.CatalogCache.Catalog", autospec=True)
-    def test_secure_params(self, mock_cc):
-        cc = CatalogCache(self.cfg)
-        cc.catalog.get_module_version.return_value = CATALOG_GET_MODULE_VERSION
-        cc.catalog.get_secure_config_params.return_value = (
+    def test_secure_params(self):
+        cc, catalog  = self.get_mocks()
+        catalog.get_module_version.return_value = CATALOG_GET_MODULE_VERSION
+        catalog.get_secure_config_params.return_value = (
             CATALOG_GET_SECURE_CONFIG_PARAMS
         )
         out = cc.get_module_info("bogus", "method")
@@ -50,11 +46,10 @@ class CatalogCacheTest(unittest.TestCase):
         self.assertIn("secure_config_params", out)
         self.assertGreater(len(out["secure_config_params"]), 0)
 
-    @patch("JobRunner.CatalogCache.Catalog", autospec=True)
-    def test_volume(self, mock_cc):
-        cc = CatalogCache(self.cfg)
+    def test_volume(self):
+        cc, catalog  = self.get_mocks()
         vols = deepcopy(CATALOG_LIST_VOLUME_MOUNTS)
-        cc.catalog.list_volume_mounts = MagicMock(return_value=vols)
+        catalog.list_volume_mounts.return_value = vols
         out = cc.get_volume_mounts("bogus", "method", "upload")
         self.assertTrue(len(out) > 0)
         self.assertIn("host_dir", out[0])


### PR DESCRIPTION
When adding tests, I found that if a test that imported CatalogCache ran prior to the catalog cache tests, the mocks stopped working. Switching to dependency injection fixed this and is a more flexible initialization pattern anyway.