### PR TITLE
Port `set_provenance` method from the Java callback server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       env:
           KB_AUTH_TOKEN: ${{ secrets.KBASE_CI_TOKEN  }}
           KB_ADMIN_AUTH_TOKEN: ${{ secrets.KBASE_CI_TOKEN  }}
-          KB_BASE_URL: https://ci.kbase.us/services
+          KB_BASE_URL: https://ci.kbase.us/services/
       run: PYTHONPATH=. pytest -m "not online" --cov=JobRunner --cov-report=xml test
 
     - name: Upload coverage to Codecov

--- a/JobRunner/provenance.py
+++ b/JobRunner/provenance.py
@@ -2,22 +2,31 @@ from datetime import datetime, timezone
 
 
 class Provenance(object):
+
     def __init__(self, params):
-        self.subactions = []
-        (module, method) = params["method"].split(".")
+        # Can generate provenance from either job input or a workspace ProvenanceAction
+        # job input takes precedence
+        # We might want to be more strict about provenance contents. For now it's pretty forgiving
+        if "." in params.get("method", ""):
+            (module, method) = params["method"].split(".")
+        else:
+            module = params.get("service")
+            method = params.get("method")
         self.actions = dict()
         t = datetime.now(timezone.utc).astimezone().replace(microsecond=0)
         desc = "KBase SDK method run via the KBase Execution Engine"
         # TODO may need to check that service-ver is set
         self.prov = {
-            "time": t.isoformat(),
+            "time": params.get("time", t.isoformat()),
             "service": module,
-            "service_ver": params["service_ver"],
+            "service_ver": params.get("service_ver", "dev"),
             "method": method,
-            "method_params": params["params"],
-            "input_ws_objects": params.get("source_ws_objects", []),
-            "subactions": [],
-            "description": desc,
+            "method_params": params.get("params", params.get("method_params", [])),
+            "input_ws_objects": params.get(
+                "source_ws_objects", params.get("input_ws_objects", [])
+            ),
+            "subactions": params.get("subactions", []),
+            "description": params.get("description", desc),
         }
 
     def add_subaction(self, data):

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Requirements:
 * `cromwell.conf` must exist in `$HOME`. It may be an empty file.
 * The env vars below must be set.
     * Required:
-        * The 2 auth token env vars (although they don't have to be a valid token)
-        * KB_BASE_URL - must start with http but otherwise can be anything
+        * The 2 auth token env vars. They must be set to a valid token that's compatible
+          with the base url.
+        * KB_BASE_URL
     * Required for MacOS:
         * JOB_DIR, since otherwise the tests attempt to mount /tmp
     * Optional:
@@ -116,6 +117,8 @@ make test
 ```
 
 There is a script at [run_tests.sh](./run_tests.sh) that can help make this process simpler.
+Note that prior to running the script, you must set the KB_AUTH_TOKEN env var to a valid
+KBase auth token for the base url.
 
 ## Using the CallBack Server 
 * Install a kb-sdk module such as DataFileUtil using `kb-sdk install` or copying from an existing apps `lib/installed_clients` directory

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# The KB_AUTH_TOKEN environment variable must be set to a valid token for the base url
+
 # Java must be installed to run this script.
 # For mac: https://www.oracle.com/java/technologies/downloads/#jdk24-mac
 
@@ -18,9 +20,9 @@ touch "$HOME"/cromwell.conf
 # uncomment this line and fill in the proper location for the docker socket if necessary
 # export DOCKER_HOST=unix:///var/run/docker.sock:
 
-# These must be set to a NON empty string or the tests will FAIL
-export KB_AUTH_TOKEN="fake"
-export KB_ADMIN_AUTH_TOKEN="fake"
+# These must be a valid KBase authentication token for the base url
+export KB_AUTH_TOKEN="$KB_AUTH_TOKEN"
+export KB_ADMIN_AUTH_TOKEN="$KB_AUTH_TOKEN"
 # Must contain http
 export KB_BASE_URL="https://ci.kbase.us/services/"
 

--- a/test/test_callback_server.py
+++ b/test/test_callback_server.py
@@ -49,7 +49,7 @@ def test_index_post(app):
 
     assert "result" in response.json
     assert response.json["result"][0]["finished"] is 0
-    data = json.dumps({"method": "bogus.get_provenance"})
+    data = json.dumps({"method": "CallbackServer.get_provenance"})
     response = _post(app, data)
     assert "result" in response.json
     assert response.json["result"][0] in [None,[]]

--- a/test/test_callback_server_integration.py
+++ b/test/test_callback_server_integration.py
@@ -1,0 +1,209 @@
+"""
+These tests run the full callback server and integrate with with job running code in
+JobRunner, unlike the other callback server tests, which just test enqueuing and dequeuing.
+
+As such, if you submit a job, it will run fully, so you may not want to do that.
+"""
+
+import os
+import pytest
+import requests
+import time
+from typing import Any
+
+from JobRunner.Callback import Callback
+
+# NOTE - the CBS is started once for this module. Don't assume it has any particular provenance
+# stored.
+
+
+# TODO make a test config or something
+_TOKEN = os.environ["KB_AUTH_TOKEN"]
+
+
+@pytest.fixture(scope="module")
+def callback_ports():
+    cb_good = Callback(ip="localhost", app_name="jr_good", allow_set_provenance=True)
+    print("Starting cb good")
+    cb_good.start_callback()
+    
+    cb_bad = Callback(ip="localhost", app_name="jr_bad", allow_set_provenance=False)
+    print("Starting cb bad")
+    cb_bad.start_callback()
+    
+    time.sleep(1)
+    
+    yield cb_good.port, cb_bad.port
+    
+    print("Stopping cb good")
+    cb_good.stop()
+    print("Stopping cb bad")
+    cb_bad.stop()
+
+
+def _post(port: int, json_body: dict[str, Any]):
+    headers = {"Authorization": _TOKEN}
+    return requests.post(f"http://localhost:{port}", json=json_body, headers=headers)
+
+
+def test_get_set_provenance_job_input_style(callback_ports):
+    port = callback_ports[0]
+
+    resp = _post(
+        port,
+        {
+            "method": "CallbackServer.set_provenance",
+            "params": [{
+                "method": "foo.bar",
+                "service_ver": "beta",
+                "params": ["whooe", "whoo"],
+                "source_ws_objects": ["1/2/3"],
+            }]
+        }
+    )
+    j = resp.json()
+    j["result"][0][0].pop("time")  # changes per test
+
+    expected = {"result": [[{
+        "service": "foo",
+        "service_ver": "beta",
+        "method": "bar",
+        "method_params": ["whooe", "whoo"],
+        "input_ws_objects": ["1/2/3"],
+        "subactions": [],
+        "description": "KBase SDK method run via the KBase Execution Engine"
+    }]]}
+    assert j == expected
+
+    time.sleep(0.1)  # give the queues time to do their thing
+    resp = _post(port, {"method":"CallbackServer.get_provenance"})
+    j = resp.json()
+    j["result"][0][0].pop("time")  # changes per test
+    assert j == expected
+
+
+def test_get_set_provenance_provenance_action_style(callback_ports):
+    port = callback_ports[0]
+
+    resp = _post(
+        port,
+        {
+            "method": "CallbackServer.set_provenance",
+            "params": [{
+                "service": "myservice",
+                "method": "mymethod",
+                "service_ver": "release",
+                "method_params": ["bing", "bang"],
+                "input_ws_objects": ["4/5/6"],
+                "time": "iso8601 timestamp goes here",
+                "subactions": [{
+                    "name": "legitmodule",
+                    "ver": "1.2.3",
+                    "code_url": "https://github.com/kbase/legitmodule.git",
+                    "commit": "thisistaotallyalegitgithuash",
+                }],
+                "description": "myprov",
+            }]
+        }
+    )
+    j = resp.json()
+    expected = {"result": [[{
+        "service": "myservice",
+        "method": "mymethod",
+        "service_ver": "release",
+        "method_params": ["bing", "bang"],
+        "input_ws_objects": ["4/5/6"],
+        "time": "iso8601 timestamp goes here",
+        "subactions": [{
+            "name": "legitmodule",
+            "ver": "1.2.3",
+            "code_url": "https://github.com/kbase/legitmodule.git",
+            "commit": "thisistaotallyalegitgithuash",
+        }],
+        "description": "myprov",
+    }]]}
+    assert j == expected
+
+    time.sleep(0.1)  # give the queues time to do their thing
+    resp = _post(port, {"method":"CallbackServer.get_provenance"})
+    j = resp.json()
+    assert j == expected
+
+
+def test_set_provenance_fail_disabled(callback_ports):
+    port = callback_ports[1]
+
+    resp = _post(
+        port,
+        {
+            "method": "CallbackServer.set_provenance",
+            "params": [{
+                "method": "foo.bar",
+                "service_ver": "beta",
+                "params": ["whooe", "whoo"],
+                "source_ws_objects": ["1/2/3"],
+            }]
+        }
+    )
+    j = resp.json()
+    assert j == {
+        "error": {
+            "code": -32000,
+            "error": "Setting provenance is not enabled",
+            "message": "Setting provenance is not enabled",
+        },
+    }
+
+
+def test_set_provenance_fail_no_params(callback_ports):
+    port = callback_ports[0]
+    err = "method params must be a list containing exactly one provenance action"
+
+    resp = _post(port, {"method": "CallbackServer.set_provenance"})
+    j = resp.json()
+    assert j == {
+        "error": {
+            "code": -32000,
+            "error": err,
+            "message": err,
+        },
+    }
+
+
+def test_set_provenance_fail_bad_params(callback_ports):
+    port = callback_ports[0]
+    err = "method params must be a list containing exactly one provenance action"
+
+    testset = [
+        None,
+        {},
+        "foo",
+        [],
+        ["foo", "bar"],
+        [[]],
+        ["thingy"]
+    ]
+    for t in testset:
+        resp = _post(port, {"method": "CallbackServer.set_provenance", "params": t})
+        j = resp.json()
+        assert j == {
+            "error": {
+                "code": -32000,
+                "error": err,
+                "message": err,
+            },
+        }
+
+
+def test_callback_method_fail_no_method(callback_ports):
+    port = callback_ports[1]
+
+    resp = _post(port, {"method": "CallbackServer.no_method"})
+    j = resp.json()
+    assert j == {
+        "error": {
+            "code": -32601,
+            "error": "No such CallbackServer method: no_method",
+            "message": "No such CallbackServer method: no_method",
+        },
+    }


### PR DESCRIPTION
The method is used for resetting provenance in `kb_sdk test` where only one instance of the CBS is run for the entire test suite, so the provenance effectively acts like a global variable. The environment variable that turns it on should only be set there.