### PR TITLE
Made default service_ver release

### DIFF
--- a/JobRunner/JobRunner.py
+++ b/JobRunner/JobRunner.py
@@ -145,7 +145,7 @@ class JobRunner(object):
         (module, method) = job_params["method"].split(".")
         service_ver = job_params.get("service_ver")
         if service_ver is None:
-            service_ver = job_params.get("context", {}).get("service_ver")
+            service_ver = job_params.get("context", {"service_ver": "release"}).get("service_ver")
 
         # TODO Fail gracefully if this step fails. For example, setting service_ver='fake'
         module_info = self.cc.get_module_info(module, service_ver)

--- a/JobRunner/MethodRunner.py
+++ b/JobRunner/MethodRunner.py
@@ -85,9 +85,10 @@ class MethodRunner:
         nowutc = datetime.utcnow().replace(tzinfo=timezone.utc)
         ts = nowutc.replace(microsecond=0).isoformat()
 
+        # TODO CODE this code block appears in 4 places in the codebase
         service_ver = params.get("service_ver")
         if service_ver is None:
-            service_ver = params.get("context", {}).get("service_ver")
+            service_ver = params.get("context", {"service_ver": "release"}).get("service_ver")
 
         ctx = {
             "call_stack": [
@@ -144,7 +145,7 @@ class MethodRunner:
         (module, method) = params["method"].split(".")
         service_ver = params.get("service_ver")
         if service_ver is None:
-            service_ver = params.get("context", {}).get("service_ver")
+            service_ver = params.get("context", {"service_ver": "release"}).get("service_ver")
 
         image = module_info["docker_img_name"]
 

--- a/JobRunner/callback_server.py
+++ b/JobRunner/callback_server.py
@@ -160,7 +160,7 @@ def _check_module_lookup(app, module, data):
     # to work the same way as the old Java server
     service_ver = data.get("service_ver")
     if service_ver is None:
-        service_ver = data.get("context", {}).get("service_ver")
+        service_ver = data.get("context", {"service_ver": "release"}).get("service_ver")
     err = f"Error looking up module {module} with version {service_ver}: "
     try:
         app.config["catcache"].get_module_info(module, service_ver)


### PR DESCRIPTION
Currently if no service ver is supplied, the job runner will use whatever version is returned by the catalog, which could be surprising for users. This change updates the JR to use `release` if no service version is supplied, which mirrors the behavior of the original Java callback service.