### PR TITLE
Port shifter changes from ee2 branch

### DIFF
--- a/JobRunner/JobRunner.py
+++ b/JobRunner/JobRunner.py
@@ -373,6 +373,14 @@ class JobRunner(object):
             self.logger.error("Failed to config . Exiting.")
             raise e
 
+        if "USE_SHIFTER" in os.environ:
+            # Replace URLs for NERSC environment if set to "https://services.kbase.us"
+            old_url = "https://services.kbase.us"
+            new_url = "https://kbase.us"
+            for key, value in config.items():
+                if isinstance(value, str) and old_url in value:
+                    config[key] = value.replace(old_url, new_url)
+
         # config["job_id"] = self.job_id
         self.logger.log(
             f"Server version of Execution Engine: {config.get('ee.server.version')}"
@@ -412,6 +420,7 @@ class JobRunner(object):
         # Submit the main job
         self.logger.log(f"Job is about to run {job_params.get('app_id')}")
 
+        # Note the self.config is not used, its the ee2 config we just grabbed and modified
         # TODO Try except for when submit or watch failure happens and correct finishjob call
         self._submit(
             config=config, job_id=self.job_id, job_params=job_params, subjob=False

--- a/scripts/jobrunner.py
+++ b/scripts/jobrunner.py
@@ -94,6 +94,11 @@ def main():
         sys.exit(1)
     ee2_suffix = ee2_url.split("/")[-1]
     base_url = ee2_url.rstrip(ee2_suffix)
+    # Replace URLs for NERSC environment if set to "https://services.kbase.us"
+    old_url = "https://services.kbase.us"
+    new_url = "https://kbase.us"
+    if "USE_SHIFTER" in os.environ and base_url.startswith(old_url):
+        base_url = base_url.replace(old_url, new_url)
 
     config = Config(workdir=os.getcwd(), job_id=job_id, base_url=base_url)
     if not os.path.exists(config.workdir):


### PR DESCRIPTION
Changes that are functionally the same as the changes in this commit are already running on prod. Due to refactoring of how configuration works, the changes on the ee2 branch could not be exactly replicated here, but they should be functionally the same.

This is impossible to test other than in situ.

Fixes: #88 

For comparison, the ee2 branch changes: https://github.com/kbase/jobRunner/compare/68d9c2710bb16e362662fb1a4db2da5afa7ddfd7..ee2