### PR TITLE
Fix bug when providing subactions in provenance

### DIFF
--- a/JobRunner/provenance.py
+++ b/JobRunner/provenance.py
@@ -25,9 +25,11 @@ class Provenance(object):
             "input_ws_objects": params.get(
                 "source_ws_objects", params.get("input_ws_objects", [])
             ),
-            "subactions": params.get("subactions", []),
+            "subactions": [],
             "description": params.get("description", desc),
         }
+        for s in params.get("subactions", []):
+            self.add_subaction(s)
 
     def add_subaction(self, data):
         if data["name"] not in self.actions:


### PR DESCRIPTION
If subactions are provided in the initial provenance or via set_provenance, they may be duplicated in the stored provenance if a module in the subaction list is run by the callback server. This fix processes initial subactions correctly.