### PR TITLE
Switch USE_SHIFTER env var name; remove scary log

### DIFF
--- a/JobRunner/DockerRunner.py
+++ b/JobRunner/DockerRunner.py
@@ -140,7 +140,7 @@ class DockerRunner:
             image_id = self.docker.images.get(name=image).id
             self.pulled[image] = image_id
         except docker.errors.ImageNotFound as e:
-            self.logger.error(f"{e}")
+            self.logger.log(f"Image not found locally, will attempt to pull. Error was:\n{e}")
 
         try:
             # If no tag is specified, will return a list

--- a/JobRunner/JobRunner.py
+++ b/JobRunner/JobRunner.py
@@ -370,7 +370,7 @@ class JobRunner(object):
         try:
             ee2_config = self.ee2.list_config()
         except Exception as e:
-            self.logger.error("Failed to get config . Exiting.")
+            self.logger.error("Failed to get config. Exiting.")
             raise e
 
         if self.config.use_external_urls:

--- a/JobRunner/JobRunner.py
+++ b/JobRunner/JobRunner.py
@@ -373,7 +373,7 @@ class JobRunner(object):
             self.logger.error("Failed to config . Exiting.")
             raise e
 
-        if "USE_SHIFTER" in os.environ:
+        if "USE_EXTERNAL_URLS" in os.environ:
             # Replace URLs for NERSC environment if set to "https://services.kbase.us"
             old_url = "https://services.kbase.us"
             new_url = "https://kbase.us"

--- a/JobRunner/JobRunner.py
+++ b/JobRunner/JobRunner.py
@@ -379,7 +379,7 @@ class JobRunner(object):
                     ee2_config[key] = value.replace(
                         Config.PROD_INTERNAL_URL_BASE, Config.PROD_EXTERNAL_URL_BASE
                     )
-            
+
         self.logger.log(
             f"Server version of Execution Engine: {ee2_config.get('ee.server.version')}"
         )

--- a/JobRunner/callback_server.py
+++ b/JobRunner/callback_server.py
@@ -177,7 +177,7 @@ def _handle_submit(app, module, method, data, token):
             f"No more than {app.config['maxjobs']} concurrently running methods are allowed"
         )
     if module != "special":
-        # "special" denotes the method call does something unusual. The module is not registered 
+        # "special" denotes the method call does something unusual. The module is not registered
         # in the catalog. Not clear how to reasonably test this case.
         # Validate the module and version using the CatalogCache before submitting the job.
         # If there is an error with the module lookup, return the error response immediately.

--- a/JobRunner/config.py
+++ b/JobRunner/config.py
@@ -34,6 +34,10 @@ def _get_admin_token():
 
 
 class Config:
+    
+    PROD_INTERNAL_URL_BASE =  "https://services.kbase.us"
+    PROD_EXTERNAL_URL_BASE =  "https://kbase.us"
+    
     def __init__(
             self,
             workdir=None,
@@ -43,7 +47,13 @@ class Config:
             max_tasks: Union[int, None] = None,
     ):
         self.job_id = job_id
+        self.use_external_urls = os.environ.get("USE_EXTERNAL_URLS", "false").lower() == "true"
         self.base_url = os.environ.get(_KB_BASE_URL, "https://ci.kbase.us/services/")
+        if self.use_external_urls and self.base_url.startswith(self.PROD_INTERNAL_URL_BASE):
+            # internal urls are only accessible inside the KBase firewall
+            self.base_url = self.base_url.replace(
+                self.PROD_INTERNAL_URL_BASE, self.PROD_EXTERNAL_URL_BASE
+            )
         self.ee2_url = None
         self.debug = False
         self.cgroup = None

--- a/JobRunner/config.py
+++ b/JobRunner/config.py
@@ -34,10 +34,10 @@ def _get_admin_token():
 
 
 class Config:
-    
+
     PROD_INTERNAL_URL_BASE =  "https://services.kbase.us"
     PROD_EXTERNAL_URL_BASE =  "https://kbase.us"
-    
+
     def __init__(
             self,
             workdir=None,

--- a/JobRunner/config.py
+++ b/JobRunner/config.py
@@ -35,8 +35,8 @@ def _get_admin_token():
 
 class Config:
 
-    PROD_INTERNAL_URL_BASE =  "https://services.kbase.us"
-    PROD_EXTERNAL_URL_BASE =  "https://kbase.us"
+    PROD_INTERNAL_URL_BASE = "https://services.kbase.us"
+    PROD_EXTERNAL_URL_BASE = "https://kbase.us"
 
     def __init__(
             self,

--- a/scripts/jobrunner.py
+++ b/scripts/jobrunner.py
@@ -94,11 +94,6 @@ def main():
         sys.exit(1)
     ee2_suffix = ee2_url.split("/")[-1]
     base_url = ee2_url.rstrip(ee2_suffix)
-    # Replace URLs for NERSC environment if set to "https://services.kbase.us"
-    old_url = "https://services.kbase.us"
-    new_url = "https://kbase.us"
-    if "USE_EXTERNAL_URLS" in os.environ and base_url.startswith(old_url):
-        base_url = base_url.replace(old_url, new_url)
 
     config = Config(workdir=os.getcwd(), job_id=job_id, base_url=base_url)
     if not os.path.exists(config.workdir):

--- a/scripts/jobrunner.py
+++ b/scripts/jobrunner.py
@@ -97,7 +97,7 @@ def main():
     # Replace URLs for NERSC environment if set to "https://services.kbase.us"
     old_url = "https://services.kbase.us"
     new_url = "https://kbase.us"
-    if "USE_SHIFTER" in os.environ and base_url.startswith(old_url):
+    if "USE_EXTERNAL_URLS" in os.environ and base_url.startswith(old_url):
         base_url = base_url.replace(old_url, new_url)
 
     config = Config(workdir=os.getcwd(), job_id=job_id, base_url=base_url)


### PR DESCRIPTION
* Switches USE_SHIFTER -> USE_EXTERNAL_URLS to better describe what the env var does
* Moves the url mangling logic into config, other than the separate ee2 config
* Swtiches an error() log to a log() log as it's not actually a error, it happens all the time and is normal.

Will need to be tested in situ at NERSC.